### PR TITLE
changes local blt config to use environment variable to hostname

### DIFF
--- a/config/blt/example.local.blt.yml
+++ b/config/blt/example.local.blt.yml
@@ -2,7 +2,7 @@
 project:
   local:
     protocol: http
-    hostname: '${project.machine_name}.docksal'
+    hostname: '${env.VIRTUAL_HOST}'
 
 # You can set custom project aliases in drush/sites/*.site.yml.
 # All local:* targets are run against drush.aliases.local.


### PR DESCRIPTION
using `${project.machine_name}.docksal` requires extra configuration by the user and the project machine name may not always match unless changed for local.blt.yml.

using `${env.VIRTUAL_HOST}` will always read the environment variable of the already set VIRTUAL_HOST so that no additional config changes are needed. This is handing when you have to clone multiple instances of the same code base to test different branches simultaneously. It is also the recommended configuration in the [Docksal and BLT blog post](https://blog.docksal.io/docksal-and-acquia-blt-1552540a3b9f).